### PR TITLE
Add missing versions to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
-<a name="0.1.0"></a>
-## 0.1.0 (2017-09-29)
+<a name="v0.1.5"></a>
+## v0.1.5 (2017-11-21)
 
-Initial release
+* Update README.md
+
+<a name="v0.1.4"></a>
+## v0.1.4 (2017-10-25)
+
+* Update README.md
+
+<a name="v0.1.3"></a>
+## v0.1.3 (2017-10-23)
+
+* Fix documentation link on crates.io
+
+<a name="v0.1.2"></a>
+## v0.1.2 (2017-10-11)
+
+* Update README.md
+
+<a name="v0.1.1"></a>
+## v0.1.1 (2017-10-05)
+
+* Update README.md
+
+<a name="v0.1.0"></a>
+## v0.1.0 (2017-09-29)
+
+Initial Release


### PR DESCRIPTION
Turns out that clog doesn't generate changelog entries for `docs` and
`chore` commits, so I had to summarize those manually.

Closes #10.